### PR TITLE
Fix: 상단 뒤로가기 버튼을 눌렀을 때의 기능 분할

### DIFF
--- a/src/pages/post/ViewPost.jsx
+++ b/src/pages/post/ViewPost.jsx
@@ -39,6 +39,7 @@ import { useNavigate } from 'react-router-dom';
 
 const ViewPost = () => {
 	const token = localStorage.getItem('token');
+	const currentUserAccountName = localStorage.getItem('userAccountName');
 	const [postData, setPostData] = useState(null);
 	const [myProfilePic, setMyProfilePic] = useState('');
 	const [myAccountName, setMyAccountName] = useState('');
@@ -189,7 +190,13 @@ const ViewPost = () => {
 	return (
 		<WrapperViewPost>
 			<NavbarWrap spaceBetween>
-				<Backspace onClick={() => navigate(-1)} />
+				<Backspace
+					onClick={() =>
+						postData.author.accountname !== currentUserAccountName
+							? navigate(-1)
+							: navigate('/myProfile')
+					}
+				/>
 				<OptionModalTab onClick={handleModalOpen}></OptionModalTab>
 			</NavbarWrap>
 

--- a/src/pages/userProfile/UserProfile.jsx
+++ b/src/pages/userProfile/UserProfile.jsx
@@ -35,7 +35,7 @@ import { BottomNavContainer } from '../../components/bottomnav/bottomnav.style';
 import axios from 'axios';
 
 import { API_URL } from '../../api';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import ProductsForSale from './ProductsForSale';
 export default function UserProfile() {
 	const location = useLocation();


### PR DESCRIPTION
* 기존에는 사용자가 게시글을 작성 -> 상세 페이지 이동 -> 수정 -> 상세 페이지 이동의 과정을 거친 후 뒤로가기 버튼을 누르면 해당 과정을 역순으로 반복했음.
* 이런 불필요한 과정을 막기 위해서, 사용자의 이름을 비교하고 게시글 상세 페이지의 author.accountname과 현재 로그인한 사용자가 동일하다면 뒤로가기 버튼을 눌렀을 때 내 프로필로 이동하고, 다르다면 이전 페이지로 이동하는 기능을 추가