### PR TITLE
Fix: Product 페이지 이전 URL 유효성 검사에서는 .com이 없으면 통과하지 못해서 수정함

### DIFF
--- a/src/pages/product/Product.jsx
+++ b/src/pages/product/Product.jsx
@@ -120,7 +120,7 @@ export default function Product() {
 			setShowToast(true);
 			setTimeout(() => {
 				navigate('../../profile/myProfile');
-			}, 3000);
+			}, 1000);
 		} catch (error) {
 			console.error(error.response);
 		}

--- a/src/pages/product/Product.jsx
+++ b/src/pages/product/Product.jsx
@@ -156,7 +156,7 @@ export default function Product() {
 		const salesLinkValue = e.target.value;
 		setSalesLink(salesLinkValue);
 		const urlPatterns =
-			/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?)$/i;
+			/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}(\/.*)?)$/i;
 
 		if (!urlPatterns.test(salesLinkValue)) {
 			setSalesLinkError('유효한 URL을 입력해주세요.');


### PR DESCRIPTION
이전의 URL 유효성 검사 정규표현식을 수정하여 .com과 같은 특정 TLD가 없어도 유효성 검사를 통과하게 수정함 
Resolves: #85