### PR TITLE
Product관련 페이지 기능 추가 및 코드 중복 개선 

### DIFF
--- a/.github/ISSUE_TEMPLATE/⚙️feature---refactoring.md
+++ b/.github/ISSUE_TEMPLATE/⚙️feature---refactoring.md
@@ -1,6 +1,6 @@
 ---
-name: "⚙️FEATURE"
-about: Feature 작업 사항을 입력해주세요.
+name: "⚙️FEATURE & Refactoring"
+about: Feature 작업 사항 혹은 Refactoring 과정을 입력해주세요.
 title: ''
 labels: ''
 assignees: ''

--- a/src/pages/product/Product.jsx
+++ b/src/pages/product/Product.jsx
@@ -7,6 +7,8 @@ import {
 	InputStyle,
 	InputWrap,
 	ProductContainer,
+	RadioCover,
+	RadioInput,
 	Upload,
 	UploadImage,
 	UploadImageBtn,
@@ -28,6 +30,8 @@ import { Helmet } from 'react-helmet';
 export default function Product() {
 	// 이미지 등록
 	const [selectedImage, setSelectedImage] = useState('');
+	// 상품 분류 선택
+	const [category, setCategory] = useState('일반');
 	// 상품명 입력
 	const [productName, setProductName] = useState('');
 	const [productNameError, setProductNameError] = useState('');
@@ -99,9 +103,14 @@ export default function Product() {
 	};
 
 	async function handleSaveButtonClick(e) {
+		let itemName = productName;
+
+		if (category !== '일반') {
+			itemName = '[' + category + ']' + ' ' + productName;
+		}
 		const productData = {
 			product: {
-				itemName: productName,
+				itemName: itemName,
 				price: parseInt(productPrice.replace(/[₩,]/g, '')),
 				link: salesLink,
 				itemImage: selectedImage,
@@ -245,6 +254,41 @@ export default function Product() {
 					</BgBtnCover>
 				</Upload>
 				<InputWrap>
+					<div>
+						<LabelStyle>상품 분류</LabelStyle>
+						<RadioCover>
+							<label>
+								<RadioInput
+									type='radio'
+									name='category'
+									value='normal'
+									checked={category === '일반'}
+									onChange={() => setCategory('일반')}
+								/>
+								일반
+							</label>
+							<label>
+								<RadioInput
+									type='radio'
+									name='option'
+									value='recommendation'
+									checked={category === '추천'}
+									onChange={() => setCategory('추천')}
+								/>
+								추천
+							</label>
+							<label>
+								<RadioInput
+									type='radio'
+									name='option'
+									value='discount'
+									checked={category === '할인'}
+									onChange={() => setCategory('할인')}
+								/>
+								할인
+							</label>
+						</RadioCover>
+					</div>
 					<InputList>
 						<LabelStyle htmlFor='product-name'>상품명</LabelStyle>
 						<InputStyle

--- a/src/pages/product/product.style.jsx
+++ b/src/pages/product/product.style.jsx
@@ -85,3 +85,26 @@ export const UploadImage = styled.img`
 	border-radius: 10px;
 	object-fit: cover;
 `;
+
+export const RadioCover = styled.div`
+	margin-top: 14px;
+	display: flex;
+	gap: 10px;
+	color: #767676;
+	font-size: 14px;
+	margin-left: -4px;
+`;
+
+export const RadioInput = styled.input`
+	appearance: none;
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	border: 0.5px solid #505050;
+	outline: none;
+
+	&:checked {
+		background-color: #81d8d0;
+		border: none;
+	}
+`;

--- a/src/pages/userProfile/ProductsForSale.jsx
+++ b/src/pages/userProfile/ProductsForSale.jsx
@@ -113,29 +113,8 @@ export default function ProductsForSale({ userAccountName }) {
 		});
 	};
 
-	useEffect(() => {
-		if (resProd.length !== 0) {
-			const product = resProd.map((item) => (
-				<ProductList
-					key={item.id}
-					onClick={() => {
-						handleModalOpen(item);
-					}}
-				>
-					<ProductImg
-						src={item.itemImage}
-						alt={`${item.itemName}의 상품 이미지`}
-					/>
-					<ProductName>{item.itemName}</ProductName>
-					<ProductPrice>{item.price.toLocaleString()}원</ProductPrice>
-				</ProductList>
-			));
-			setProductData(product);
-		}
-	}, [resProd]);
-
-	const handleShowAllProducts = () => {
-		const products = resProd.map((item) => (
+	const createProductList = (items) => {
+		return items.map((item) => (
 			<ProductList
 				key={item.id}
 				onClick={() => {
@@ -150,6 +129,17 @@ export default function ProductsForSale({ userAccountName }) {
 				<ProductPrice>{item.price.toLocaleString()}원</ProductPrice>
 			</ProductList>
 		));
+	};
+
+	useEffect(() => {
+		if (resProd.length !== 0) {
+			const product = createProductList(resProd);
+			setProductData(product);
+		}
+	}, [resProd]);
+
+	const handleShowAllProducts = () => {
+		const products = createProductList(resProd);
 		setProductData(products);
 	};
 
@@ -157,21 +147,7 @@ export default function ProductsForSale({ userAccountName }) {
 		const recommendedProducts = resProd.filter((item) =>
 			item.itemName.includes('[추천]')
 		);
-		const products = recommendedProducts.map((item) => (
-			<ProductList
-				key={item.id}
-				onClick={() => {
-					handleModalOpen(item);
-				}}
-			>
-				<ProductImg
-					src={item.itemImage}
-					alt={`${item.itemName}의 상품 이미지`}
-				/>
-				<ProductName>{item.itemName}</ProductName>
-				<ProductPrice>{item.price.toLocaleString()}원</ProductPrice>
-			</ProductList>
-		));
+		const products = createProductList(recommendedProducts);
 		setProductData(products);
 	};
 
@@ -179,21 +155,7 @@ export default function ProductsForSale({ userAccountName }) {
 		const discountedProducts = resProd.filter((item) =>
 			item.itemName.includes('[할인]')
 		);
-		const products = discountedProducts.map((item) => (
-			<ProductList
-				key={item.id}
-				onClick={() => {
-					handleModalOpen(item);
-				}}
-			>
-				<ProductImg
-					src={item.itemImage}
-					alt={`${item.itemName}의 상품 이미지`}
-				/>
-				<ProductName>{item.itemName}</ProductName>
-				<ProductPrice>{item.price.toLocaleString()}원</ProductPrice>
-			</ProductList>
-		));
+		const products = createProductList(discountedProducts);
 		setProductData(products);
 	};
 

--- a/src/pages/userProfile/ProductsForSale.jsx
+++ b/src/pages/userProfile/ProductsForSale.jsx
@@ -31,6 +31,7 @@ export default function ProductsForSale({ userAccountName }) {
 	const [selectedProduct, setSelectedProduct] = useState(null);
 	const [myProfile, setMyProfile] = useState();
 	const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+	const [selectedButton, setSelectedButton] = useState(0);
 	const navigate = useNavigate();
 	const accountname = userAccountName;
 	const url = API_URL;
@@ -201,13 +202,32 @@ export default function ProductsForSale({ userAccountName }) {
 			{resProd.length === 0 ? null : (
 				<WrapAll>
 					<Title>함께 떠나는 상품</Title>
-					<SortedButton first onClick={handleShowAllProducts}>
+					<SortedButton
+						first
+						onClick={() => {
+							setSelectedButton(0);
+							handleShowAllProducts();
+						}}
+						selected={selectedButton === 0}
+					>
 						# 전체 상품
 					</SortedButton>
-					<SortedButton onClick={handleShowRecommendedItems}>
+					<SortedButton
+						onClick={() => {
+							setSelectedButton(1);
+							handleShowRecommendedItems();
+						}}
+						selected={selectedButton === 1}
+					>
 						🔥추천 상품
 					</SortedButton>
-					<SortedButton onClick={handleShowDiscountedItems}>
+					<SortedButton
+						onClick={() => {
+							setSelectedButton(2);
+							handleShowDiscountedItems();
+						}}
+						selected={selectedButton === 2}
+					>
 						🤑할인 상품
 					</SortedButton>
 					<Scroll>

--- a/src/pages/userProfile/ProductsForSaleEdit.jsx
+++ b/src/pages/userProfile/ProductsForSaleEdit.jsx
@@ -8,6 +8,8 @@ import {
 	InputStyle,
 	InputWrap,
 	ProductContainer,
+	RadioCover,
+	RadioInput,
 	Upload,
 	UploadImage,
 	UploadImageBtn,
@@ -29,6 +31,8 @@ import { Helmet } from 'react-helmet';
 export default function ProductsForSaleEdit() {
 	// 이미지 등록
 	const [selectedImage, setSelectedImage] = useState('');
+	// 상품 분류 선택
+	const [category, setCategory] = useState('일반');
 	// 상품명 입력
 	const [productName, setProductName] = useState('');
 	const [productNameError, setProductNameError] = useState('');
@@ -126,9 +130,16 @@ export default function ProductsForSaleEdit() {
 	};
 
 	async function handleSaveButtonClick(e) {
+		const updatedCategory = category !== '일반' ? '[' + category + ']' : '';
+		const updatedItemName = productName.replace(/^\[[^\]]*\]\s*/, '');
+		const itemName = updatedCategory + ' ' + updatedItemName;
+
+		// if (category !== '일반') {
+		// 	itemName = '[' + category + ']' + ' ' + productName;
+		// }
 		const productData = {
 			product: {
-				itemName: productName,
+				itemName: itemName,
 				price: parseInt(productPrice.replace(/[₩,]/g, '')),
 				link: salesLink,
 				itemImage: selectedImage,
@@ -272,6 +283,41 @@ export default function ProductsForSaleEdit() {
 					</BgBtnCover>
 				</Upload>
 				<InputWrap>
+					<div>
+						<LabelStyle>상품 분류</LabelStyle>
+						<RadioCover>
+							<label>
+								<RadioInput
+									type='radio'
+									name='option'
+									value='normal'
+									checked={category === '일반'}
+									onChange={() => setCategory('일반')}
+								/>
+								일반
+							</label>
+							<label>
+								<RadioInput
+									type='radio'
+									name='option'
+									value='recommendation'
+									checked={category === '추천'}
+									onChange={() => setCategory('추천')}
+								/>
+								추천
+							</label>
+							<label>
+								<RadioInput
+									type='radio'
+									name='option'
+									value='discount'
+									checked={category === '할인'}
+									onChange={() => setCategory('할인')}
+								/>
+								할인
+							</label>
+						</RadioCover>
+					</div>
 					<InputList>
 						<LabelStyle htmlFor='product-name'>상품명</LabelStyle>
 						<InputStyle

--- a/src/pages/userProfile/productsForSale.style.jsx
+++ b/src/pages/userProfile/productsForSale.style.jsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const WrapAll = styled.div`
 	background: white;
@@ -50,6 +50,12 @@ export const SortedButton = styled.button`
 		background-color: #81d8d0;
 		color: white;
 	}
+	${({ selected }) =>
+		selected &&
+		css`
+			background-color: #81d8d0;
+			color: #fff;
+		`}
 `;
 
 export const ProductsContainer = styled.ul`


### PR DESCRIPTION
## Motivation
- 상품 등록/수정 페이지 사용자가 기존에 직접 기입해야 했던 상품 분류를 좀 더 편리하게 선택할 수 있는 기능으로 추가
- 사용자에게 사용자가 어떤 정렬 기준(버튼)을 선택했는지 시각적으로 보여주도록 개선 
- 중복되는 코드를 줄여서 코드의 재사용성을 높이고 가독성을 개선

## Key Changes
[[Feat] 상품 수정/등록 페이지에서 추천, 할인 상품을 유저가 직접 선택할 수 있게 변경 #107](https://github.com/FRONTENDSCHOOL5/final-04-fearless4/issues/107)
[[Feat] 상품에서 정렬 버튼 선택했을 때, 선택된 버튼의 색을 변경 #110](https://github.com/FRONTENDSCHOOL5/final-04-fearless4/issues/110)
[[Refactor] ProductsForSale 컴포넌트에서 상품 목록을 렌더링하는 부분을 createProductList 함수로 분리하여 중복된 코드를 줄임 #114](https://github.com/FRONTENDSCHOOL5/final-04-fearless4/issues/114)

## To Reviewers
상품 페이지 관련해서 오류 발생할 때 리뷰 부탁드리겠습니다!
