### PR TITLE
[Refactor] Profile, Follow 페이지 리팩토링

### DIFF
--- a/src/api/followApi.js
+++ b/src/api/followApi.js
@@ -1,11 +1,13 @@
 import { accessInstance } from './axiosInstance';
 
-export const getFollow = async (accountname, pageParam, follow) => {
+export const getFollow = async (accountname, pageParam, follow, nextPage) => {
 	try {
 		const res = await accessInstance.get(
 			`/profile/${accountname}/${follow}/?limit=10&skip=${pageParam}`
 		);
 		const { data } = res;
+		data.length >= 10 ? nextPage(true) : nextPage(false);
+
 		return {
 			data: data,
 			nextPage: pageParam,

--- a/src/api/followApi.js
+++ b/src/api/followApi.js
@@ -16,3 +16,19 @@ export const getFollow = async (accountname, pageParam, follow, nextPage) => {
 		console.log(error);
 	}
 };
+
+export const postFollow = async (accountname) => {
+	try {
+		const res = await accessInstance.post(`/profile/${accountname}/follow`);
+	} catch (error) {
+		console.error(error);
+	}
+};
+
+export const delUnFollow = async (accountname) => {
+	try {
+		const res = await accessInstance.delete(`/profile/${accountname}/unfollow`);
+	} catch (error) {
+		console.error(error);
+	}
+};

--- a/src/api/followApi.js
+++ b/src/api/followApi.js
@@ -1,0 +1,16 @@
+import { accessInstance } from './axiosInstance';
+
+export const getFollow = async (accountname, pageParam, follow) => {
+	try {
+		const res = await accessInstance.get(
+			`/profile/${accountname}/${follow}/?limit=10&skip=${pageParam}`
+		);
+		const { data } = res;
+		return {
+			data: data,
+			nextPage: pageParam,
+		};
+	} catch (error) {
+		console.log(error);
+	}
+};

--- a/src/api/homefeedApi.js
+++ b/src/api/homefeedApi.js
@@ -9,6 +9,7 @@ const getHomefeed = async (pageParam) => {
 	return {
 		data: posts,
 		nextPage: pageParam,
+		isLast: posts.length % 10 !== 0,
 	};
 };
 

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -40,7 +40,11 @@ export const delUnFollow = async (accountname) => {
 
 export const postAccountValid = async (accountname) => {
 	try {
-		const res = await instance.post('/user/accountnamevalid/', accountname);
+		const res = await instance.post(`/user/accountnamevalid/`, {
+			user: {
+				accountname: accountname,
+			},
+		});
 		return res.data.message;
 	} catch (error) {
 		console.error(error);

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -3,7 +3,6 @@ import { accessInstance, instance } from './axiosInstance';
 export const getUserInfo = async (accountname) => {
 	try {
 		const res = await accessInstance.get(`/profile/${accountname}`);
-		console.log(res.data.profile);
 		return res.data.profile;
 	} catch (error) {
 		console.error(error);
@@ -13,7 +12,6 @@ export const getUserInfo = async (accountname) => {
 export const getMyInfo = async () => {
 	try {
 		const res = await accessInstance.get('/user/myinfo');
-		console.log(res.data.user);
 		return res.data.user;
 	} catch (error) {
 		console.error(error);
@@ -23,7 +21,6 @@ export const getMyInfo = async () => {
 export const postFollow = async (accountname) => {
 	try {
 		const res = await accessInstance.post(`/profile/${accountname}/follow`);
-		console.log(res);
 	} catch (error) {
 		console.error(error);
 	}
@@ -32,7 +29,6 @@ export const postFollow = async (accountname) => {
 export const delUnFollow = async (accountname) => {
 	try {
 		const res = await accessInstance.delete(`/profile/${accountname}/unfollow`);
-		console.log(res);
 	} catch (error) {
 		console.error(error);
 	}
@@ -51,9 +47,9 @@ export const postAccountValid = async (accountname) => {
 	}
 };
 
-export const putProfileEdit = async (accountname) => {
+export const putProfileEdit = async (userData) => {
 	try {
-		const res = await accessInstance.put('/user/', accountname);
+		const res = await accessInstance.put('/user/', userData);
 	} catch (error) {
 		console.error('에러입니다.', error);
 	}

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -9,6 +9,16 @@ export const getUserInfo = async (accountname) => {
 	}
 };
 
+export const getMyInfo = async () => {
+	try {
+		const res = await accessInstance.get('/user/myinfo');
+		console.log(res.data.user);
+		return res.data.user;
+	} catch (error) {
+		console.error(error);
+	}
+};
+
 export const postFollow = async (accountname) => {
 	try {
 		const res = await accessInstance.post(`/profile/${accountname}/follow`);

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -18,22 +18,6 @@ export const getMyInfo = async () => {
 	}
 };
 
-export const postFollow = async (accountname) => {
-	try {
-		const res = await accessInstance.post(`/profile/${accountname}/follow`);
-	} catch (error) {
-		console.error(error);
-	}
-};
-
-export const delUnFollow = async (accountname) => {
-	try {
-		const res = await accessInstance.delete(`/profile/${accountname}/unfollow`);
-	} catch (error) {
-		console.error(error);
-	}
-};
-
 export const postAccountValid = async (accountname) => {
 	try {
 		const res = await instance.post(`/user/accountnamevalid/`, {

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -3,6 +3,7 @@ import { accessInstance, instance } from './axiosInstance';
 export const getUserInfo = async (accountname) => {
 	try {
 		const res = await accessInstance.get(`/profile/${accountname}`);
+		console.log(res.data.profile);
 		return res.data.profile;
 	} catch (error) {
 		console.error(error);
@@ -22,6 +23,7 @@ export const getMyInfo = async () => {
 export const postFollow = async (accountname) => {
 	try {
 		const res = await accessInstance.post(`/profile/${accountname}/follow`);
+		console.log(res);
 	} catch (error) {
 		console.error(error);
 	}
@@ -30,6 +32,7 @@ export const postFollow = async (accountname) => {
 export const delUnFollow = async (accountname) => {
 	try {
 		const res = await accessInstance.delete(`/profile/${accountname}/unfollow`);
+		console.log(res);
 	} catch (error) {
 		console.error(error);
 	}

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -50,6 +50,7 @@ export const postAccountValid = async (accountname) => {
 export const putProfileEdit = async (userData) => {
 	try {
 		const res = await accessInstance.put('/user/', userData);
+		console.log(res);
 	} catch (error) {
 		console.error('에러입니다.', error);
 	}

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -1,4 +1,4 @@
-import { accessInstance } from './axiosInstance';
+import { accessInstance, instance } from './axiosInstance';
 
 export const getUserInfo = async (accountname) => {
 	try {
@@ -22,5 +22,22 @@ export const delUnFollow = async (accountname) => {
 		const res = await accessInstance.delete(`/profile/${accountname}/unfollow`);
 	} catch (error) {
 		console.error(error);
+	}
+};
+
+export const postAccountValid = async (accountname) => {
+	try {
+		const res = await instance.post('/user/accountnamevalid/', accountname);
+		return res.data.message;
+	} catch (error) {
+		console.error(error);
+	}
+};
+
+export const putProfileEdit = async (accountname) => {
+	try {
+		const res = await accessInstance.put('/user/', accountname);
+	} catch (error) {
+		console.error('에러입니다.', error);
 	}
 };

--- a/src/components/bottomnav/bottomnav.style.jsx
+++ b/src/components/bottomnav/bottomnav.style.jsx
@@ -48,7 +48,6 @@ export function BottomNavContainer(props) {
 	const [isMessageMouseOver, setIsMessageMouseOver] = useState(false);
 	const [isPostMouseOver, setIsPostMouseOver] = useState(false);
 	const [isProfileMouseOver, setIsProfileMouseOver] = useState(false);
-	const myAccountName = localStorage.getItem('userAccountName');
 
 	const handleMouseOver = (e) => {
 		if (e.target.id === 'home') {
@@ -121,7 +120,7 @@ export function BottomNavContainer(props) {
 				/>
 				<span className='nav-text'>게시물 작성</span>
 			</NavLink>
-			<NavLink to={`/profile/${myAccountName}/`}>
+			<NavLink to={`/profile`}>
 				<NavIcon
 					id='profile'
 					src={

--- a/src/components/post/Post.jsx
+++ b/src/components/post/Post.jsx
@@ -90,7 +90,7 @@ export function Post({ postId }) {
 			}
 		};
 		getpostData();
-	}, [postInstance, postId]);
+	}, [postId]);
 
 	const handleHeartClick = async () => {
 		try {

--- a/src/pages/follow/Follow.jsx
+++ b/src/pages/follow/Follow.jsx
@@ -116,12 +116,14 @@ export default function Follwers() {
 			<Wrapper>
 				{isLoading && follower.length !== 0
 					? follower.map((item, index) => {
-							return follower.length - 1 !== index ? (
+							return (
 								<UserWrap key={item._id}>
 									<UserFlexWrap>
 										<UserProfileImg
 											onClick={() => {
-												navigate(`../../${item.accountname}`);
+												myAccountName === item.accountname
+													? navigate('../../../profile')
+													: navigate(`../../${item.accountname}`);
 											}}
 										>
 											<UserFollowImage
@@ -132,7 +134,9 @@ export default function Follwers() {
 										</UserProfileImg>
 										<UserContent
 											onClick={() => {
-												navigate(`../../${item.accountname}`);
+												myAccountName === item.accountname
+													? navigate('../../../profile')
+													: navigate(`../../${item.accountname}`);
 											}}
 										>
 											<UserFollowNickName>{item.username}</UserFollowNickName>
@@ -151,43 +155,6 @@ export default function Follwers() {
 										</FollowButton>
 									)}
 								</UserWrap>
-							) : (
-								<>
-									<UserWrap key={item._id}>
-										<UserFlexWrap>
-											<UserProfileImg
-												onClick={() => {
-													navigate(`../../${item.accountname}`);
-												}}
-											>
-												<UserFollowImage
-													src={item.image}
-													onError={handleImgError}
-													alt='유저 프로필 이미지입니다.'
-												/>
-											</UserProfileImg>
-											<UserContent
-												onClick={() => {
-													navigate(`../../${item.accountname}`);
-												}}
-											>
-												<UserFollowNickName>{item.username}</UserFollowNickName>
-												<UserFollowIntro>{item.intro}</UserFollowIntro>
-											</UserContent>
-										</UserFlexWrap>
-										{!(myAccountName === item.accountname) && (
-											<FollowButton
-												type='button'
-												follow={item.isFollow}
-												onClick={(e) => {
-													handleFollowChange(index, item.accountname, e);
-												}}
-											>
-												{item.isFollow === true ? '취소' : '팔로우'}
-											</FollowButton>
-										)}
-									</UserWrap>
-								</>
 							);
 					  })
 					: isLoading &&

--- a/src/pages/follow/Follow.jsx
+++ b/src/pages/follow/Follow.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
 	Backspace,
@@ -25,72 +25,151 @@ import FollowUnknown from './FollowUnknown';
 import Loading from '../../components/loading/Loading';
 import { Helmet } from 'react-helmet';
 import { useInView } from 'react-intersection-observer';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getFollow } from '../../api/followApi';
 
 export default function Follwers() {
-	const [follower, setFollower] = useState([]);
-	const [isLoading, setIsLoading] = useState(false);
+	// const [follower, setFollower] = useState([]);
+	const [newFollow, setNewFollow] = useState([]);
+	// const [isLoading, setIsLoading] = useState(false);
 	const navigate = useNavigate();
-	const accountname = useParams().accountUsername;
-	const follow = useParams().follow;
+	const accountUsername = useParams().accountUsername;
+	const followPage = useParams().follow;
 	const token = localStorage.getItem('token');
 	const myAccountName = localStorage.getItem('userAccountName');
 	const url = API_URL;
+	const count = useRef(0);
 	const [ref, inView] = useInView();
-	const [skip, setSkip] = useState(0);
-	const [hasNextPage, setHasNextPage] = useState(true);
+	// const [skip, setSkip] = useState(0);
+	// const [hasNextPage, setHasNextPage] = useState(true);
 
-	const followerData = async () => {
-		try {
-			const res = await axios({
-				method: 'GET',
-				url: `${url}/profile/${accountname}/${follow}/?limit=10&skip=${skip}`,
-				headers: {
-					Authorization: `Bearer ${token}`,
-					'Content-type': 'application/json',
-				},
-			});
-			setIsLoading(true);
-			const updateFollowing = res.data.map((item) => ({
-				...item,
-				isFollow: item.isfollow,
-			}));
-			updateFollowing.length >= 10
-				? setHasNextPage(true)
-				: setHasNextPage(false);
-			setFollower([...follower, ...updateFollowing]);
-			setSkip((prev) => prev + 10);
-		} catch (error) {
-			console.log('에러입니다', error);
+	const {
+		data: followData,
+		isLoading,
+		fetchNextPage,
+		hasNextPage,
+	} = useInfiniteQuery(
+		['getFollowData'],
+		({
+			accountname = accountUsername ? myAccountName : accountUsername,
+			pageParam = count.current,
+			follow = followPage,
+		}) => getFollow(accountname, pageParam, follow),
+		{
+			getNextPageParam: (lastPage) => lastPage.nextPage + 10,
 		}
-	};
-
-	console.log(follower);
+	);
+	console.log(followData);
 
 	useEffect(() => {
-		inView && followerData();
+		if (!isLoading) {
+			if (inView) {
+				count.current += 1;
+				fetchNextPage();
+			}
+		}
 	}, [inView, isLoading]);
 
-	const handleFollowChange = async (index, accountname, e) => {
-		e.preventDefault();
-		const updateFollowing = [...follower];
-		updateFollowing[index].isFollow = !follower[index].isFollow;
-		setFollower(updateFollowing);
-		try {
-			const res = await axios({
-				method: !follower[index].isFollow ? 'DELETE' : 'POST',
-				url: `${url}/profile/${accountname}/${
-					!follower[index].isFollow ? 'unfollow' : 'follow'
-				}`,
-				headers: {
-					Authorization: `Bearer ${token}`,
-					'Content-type': 'application/json',
-				},
-			});
-			console.log(res);
-		} catch (error) {
-			console.log('에러입니다', error);
-		}
-	};
+	useEffect(() => {
+		const newFollowList = followData?.pages.map((page) =>
+			page.data.map((follow) => {
+				return (
+					<UserWrap key={follow._id}>
+						<UserFlexWrap>
+							<UserProfileImg
+								onClick={() => {
+									myAccountName === follow.accountname
+										? navigate('../../../profile')
+										: navigate(`../../${follow.accountname}`);
+								}}
+							>
+								<UserFollowImage
+									src={follow.image}
+									onError={handleImgError}
+									alt={`${follow.username} 프로필 이미지입니다.`}
+								/>
+							</UserProfileImg>
+							<UserContent
+								onClick={() => {
+									myAccountName === follow.accountname
+										? navigate('../../../profile')
+										: navigate(`../../${follow.accountname}`);
+								}}
+							>
+								<UserFollowNickName>{follow.username}</UserFollowNickName>
+								<UserFollowIntro>{follow.intro}</UserFollowIntro>
+							</UserContent>
+						</UserFlexWrap>
+						{!(myAccountName === follow.accountname) && (
+							<FollowButton
+								type='button'
+								follow={follow.isFollow}
+								// onClick={(e) => {
+								// 	handleFollowChange(index, item.accountname, e);
+								// }}
+							>
+								{follow.isFollow === true ? '취소' : '팔로우'}
+							</FollowButton>
+						)}
+					</UserWrap>
+				);
+			})
+		);
+		setNewFollow(newFollowList);
+	}, [followData]);
+
+	// const followerData = async () => {
+	// 	try {
+	// 		const res = await axios({
+	// 			method: 'GET',
+	// 			url: `${url}/profile/${accountname}/${follow}/?limit=10&skip=${skip}`,
+	// 			headers: {
+	// 				Authorization: `Bearer ${token}`,
+	// 				'Content-type': 'application/json',
+	// 			},
+	// 		});
+	// 		setIsLoading(true);
+	// 		const updateFollowing = res.data.map((item) => ({
+	// 			...item,
+	// 			isFollow: item.isfollow,
+	// 		}));
+	// 		updateFollowing.length >= 10
+	// 			? setHasNextPage(true)
+	// 			: setHasNextPage(false);
+	// 		setFollower([...follower, ...updateFollowing]);
+	// 		setSkip((prev) => prev + 10);
+	// 	} catch (error) {
+	// 		console.log('에러입니다', error);
+	// 	}
+	// };
+
+	// console.log(follower);
+
+	// useEffect(() => {
+	// 	inView && followerData();
+	// }, [inView, isLoading]);
+
+	// const handleFollowChange = async (index, accountname, e) => {
+	// 	e.preventDefault();
+	// 	const updateFollowing = [...follower];
+	// 	updateFollowing[index].isFollow = !follower[index].isFollow;
+	// 	setFollower(updateFollowing);
+	// 	try {
+	// 		const res = await axios({
+	// 			method: !follower[index].isFollow ? 'DELETE' : 'POST',
+	// 			url: `${url}/profile/${accountname}/${
+	// 				!follower[index].isFollow ? 'unfollow' : 'follow'
+	// 			}`,
+	// 			headers: {
+	// 				Authorization: `Bearer ${token}`,
+	// 				'Content-type': 'application/json',
+	// 			},
+	// 		});
+	// 		console.log(res);
+	// 	} catch (error) {
+	// 		console.log('에러입니다', error);
+	// 	}
+	// };
 
 	const handleImgError = (e) => {
 		e.target.src = userNoneProfile;
@@ -100,7 +179,7 @@ export default function Follwers() {
 		<>
 			<Helmet>
 				<title>{`TravelUs | ${
-					follow === 'follower' ? '팔로워' : '팔로잉'
+					followPage === 'follower' ? '팔로워' : '팔로잉'
 				}`}</title>
 			</Helmet>
 			<NavbarWrap>
@@ -110,61 +189,17 @@ export default function Follwers() {
 					}}
 				/>
 				<NavbarTitle>{`${
-					follow === 'follower' ? 'Followers' : 'Followings'
+					followPage === 'follower' ? 'Followers' : 'Followings'
 				}`}</NavbarTitle>
 			</NavbarWrap>
 			<Wrapper>
-				{isLoading && follower.length !== 0
-					? follower.map((item, index) => {
-							return (
-								<UserWrap key={item._id}>
-									<UserFlexWrap>
-										<UserProfileImg
-											onClick={() => {
-												myAccountName === item.accountname
-													? navigate('../../../profile')
-													: navigate(`../../${item.accountname}`);
-											}}
-										>
-											<UserFollowImage
-												src={item.image}
-												onError={handleImgError}
-												alt={`${item.username} 프로필 이미지입니다.`}
-											/>
-										</UserProfileImg>
-										<UserContent
-											onClick={() => {
-												myAccountName === item.accountname
-													? navigate('../../../profile')
-													: navigate(`../../${item.accountname}`);
-											}}
-										>
-											<UserFollowNickName>{item.username}</UserFollowNickName>
-											<UserFollowIntro>{item.intro}</UserFollowIntro>
-										</UserContent>
-									</UserFlexWrap>
-									{!(myAccountName === item.accountname) && (
-										<FollowButton
-											type='button'
-											follow={item.isFollow}
-											onClick={(e) => {
-												handleFollowChange(index, item.accountname, e);
-											}}
-										>
-											{item.isFollow === true ? '취소' : '팔로우'}
-										</FollowButton>
-									)}
-								</UserWrap>
-							);
-					  })
-					: isLoading &&
-					  (!follower || follower.length === 0) && <FollowUnknown />}
-				{!isLoading && <Loading />}
+				{followData?.pages[0].data.length > 0
+					? newFollow
+					: !isLoading && <FollowUnknown />}
+				{isLoading && <Loading />}
 				{hasNextPage && (
 					<>
-						{/* {<LoadingText>Loading...</LoadingText>} */}
-
-						<ScrollRef ref={ref}></ScrollRef>
+						<div ref={ref} />
 					</>
 				)}
 			</Wrapper>

--- a/src/pages/follow/Follow.jsx
+++ b/src/pages/follow/Follow.jsx
@@ -69,9 +69,9 @@ export default function Follwers() {
 		}
 	}, [inView]);
 
-	// useEffect(() => {
-	// 	queryClient.removeQueries({ queryKey: 'getFollowData' });
-	// }, []);
+	useEffect(() => {
+		queryClient.removeQueries({ queryKey: 'getFollowData' });
+	}, []);
 
 	useEffect(() => {
 		const newFollowList = followData?.pages.map((page) =>

--- a/src/pages/follow/Follow.jsx
+++ b/src/pages/follow/Follow.jsx
@@ -6,8 +6,6 @@ import {
 	NavbarWrap,
 } from '../../components/navbar/navbar.style';
 import {
-	LoadingText,
-	ScrollRef,
 	UserContent,
 	UserFlexWrap,
 	UserFollowImage,
@@ -17,10 +15,8 @@ import {
 	UserWrap,
 	Wrapper,
 } from './follow.style';
-import { FollowButton, MoreButton } from '../../components/button/button.style';
-import axios from 'axios';
+import { FollowButton } from '../../components/button/button.style';
 import userNoneProfile from '../../assets/image/profilePic.png';
-import { API_URL } from '../../api';
 import FollowUnknown from './FollowUnknown';
 import Loading from '../../components/loading/Loading';
 import { Helmet } from 'react-helmet';
@@ -30,8 +26,7 @@ import {
 	useMutation,
 	useQueryClient,
 } from '@tanstack/react-query';
-import { getFollow } from '../../api/followApi';
-import { delUnFollow, postFollow } from '../../api/profileApi';
+import { delUnFollow, getFollow, postFollow } from '../../api/followApi';
 
 export default function Follwers() {
 	const [newFollow, setNewFollow] = useState([]);
@@ -74,9 +69,9 @@ export default function Follwers() {
 		}
 	}, [inView]);
 
-	useEffect(() => {
-		queryClient.removeQueries({ queryKey: 'getFollowData' });
-	}, []);
+	// useEffect(() => {
+	// 	queryClient.removeQueries({ queryKey: 'getFollowData' });
+	// }, []);
 
 	useEffect(() => {
 		const newFollowList = followData?.pages.map((page) =>

--- a/src/pages/follow/Follow.jsx
+++ b/src/pages/follow/Follow.jsx
@@ -36,7 +36,7 @@ export default function Follwers() {
 	const myAccountName = localStorage.getItem('userAccountName');
 	const count = useRef(0);
 	const [ref, inView] = useInView();
-	const [hasNextPage, setHasNextPage] = useState(false);
+	const [hasNextPage, setHasNextPage] = useState(true);
 	const queryClient = useQueryClient();
 
 	const {
@@ -67,7 +67,7 @@ export default function Follwers() {
 				fetchNextPage();
 			}
 		}
-	}, [inView]);
+	}, [inView, isLoading]);
 
 	useEffect(() => {
 		queryClient.removeQueries({ queryKey: 'getFollowData' });

--- a/src/pages/homeFeed/Homefeed.jsx
+++ b/src/pages/homeFeed/Homefeed.jsx
@@ -50,21 +50,17 @@ export default function Homefeed() {
 		queryClient.removeQueries({ queryKey: 'getFeedPosts' });
 	}, []);
 
-	console.log(followingFeedData?.pages);
-	console.log(count.current);
-
 	useEffect(() => {
 		const newPosts = followingFeedData?.pages.map((page) =>
 			page.data.map((post) => {
 				return (
-					<>
+					<React.Fragment key={post.id}>
 						<PostDeleteContext.Provider
-							key={post.id}
 							value={{ deletedPostId, setDeletedPostId }}
 						>
 							<HomeFollower postId={post.id} />
 						</PostDeleteContext.Provider>
-					</>
+					</React.Fragment>
 				);
 			})
 		);

--- a/src/pages/homeFeed/Homefeed.jsx
+++ b/src/pages/homeFeed/Homefeed.jsx
@@ -12,7 +12,7 @@ import { BottomNavContainer } from '../../components/bottomnav/bottomnav.style';
 import Loading from '../../components/loading/Loading.jsx';
 import { Helmet } from 'react-helmet';
 
-import { useInfiniteQuery } from '@tanstack/react-query'; //react-query
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'; //react-query
 import { useInView } from 'react-intersection-observer'; //라이브러리
 import getHomefeed from '../../api/homefeedApi.js';
 
@@ -22,28 +22,33 @@ export default function Homefeed() {
 	const [ref, inView] = useInView();
 	const count = useRef(0);
 	const [newPost, setPost] = useState([]);
+	const queryClient = useQueryClient();
 
 	const {
 		data: followingFeedData,
 		isLoading,
 		fetchNextPage,
-		hasNextPage,
 	} = useInfiniteQuery(
 		['getFeedPosts'],
 		({ pageParam = count.current }) => getHomefeed(pageParam),
 		{
 			getNextPageParam: (lastPage) => lastPage.nextPage + 10,
+			refetchOnWindowFocus: false,
 		}
 	);
 
 	useEffect(() => {
 		if (!isLoading) {
-			if (inView) {
+			if (inView && !followingFeedData?.pages[count.current].isLast) {
 				count.current += 1;
 				fetchNextPage();
 			}
 		}
-	}, [inView, isLoading]);
+	}, [inView]);
+
+	useEffect(() => {
+		queryClient.removeQueries({ queryKey: 'getFeedPosts' });
+	}, []);
 
 	console.log(followingFeedData?.pages);
 	console.log(count.current);
@@ -52,12 +57,14 @@ export default function Homefeed() {
 		const newPosts = followingFeedData?.pages.map((page) =>
 			page.data.map((post) => {
 				return (
-					<PostDeleteContext.Provider
-						key={post.id}
-						value={{ deletedPostId, setDeletedPostId }}
-					>
-						<HomeFollower postId={post.id} />
-					</PostDeleteContext.Provider>
+					<>
+						<PostDeleteContext.Provider
+							key={post.id}
+							value={{ deletedPostId, setDeletedPostId }}
+						>
+							<HomeFollower postId={post.id} />
+						</PostDeleteContext.Provider>
+					</>
 				);
 			})
 		);
@@ -82,14 +89,10 @@ export default function Homefeed() {
 				{followingFeedData?.pages[0].data.length > 0
 					? newPost
 					: !isLoading && <NoFeed />}
+				<div ref={ref} />
 
 				<BottomNavContainer home />
 				{isLoading && <Loading />}
-				{hasNextPage && (
-					<>
-						<div ref={ref} />
-					</>
-				)}
 			</HomefeedWrap>
 		</>
 	);

--- a/src/pages/page404/Page404.jsx
+++ b/src/pages/page404/Page404.jsx
@@ -19,7 +19,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 
-export default function Page404() {
+export default function Page404(props) {
 	const navigate = useNavigate();
 	return (
 		<>
@@ -32,7 +32,7 @@ export default function Page404() {
 				<NotFoundText>
 					404
 					<br />
-					Page not Found
+					{props.message ? <>{props.message} </> : <>page not Found </>}
 				</NotFoundText>
 				<CatWrap>
 					<Cat404Img src={Cat404} />

--- a/src/pages/userProfile/MyProfileEdit.jsx
+++ b/src/pages/userProfile/MyProfileEdit.jsx
@@ -45,21 +45,21 @@ export default function ProfileSetup() {
 	const [showSizeOverToast, setShowSizeOverToast] = useState(false);
 	const location = useLocation();
 	const navigate = useNavigate();
-	const profileId = useParams().accountUsername;
+	const accountId = localStorage.getItem('userAccountName');
 	const profileName = location.state.profileName;
 	const profileIntro = location.state.profileIntro;
 	const profileImg = location.state.profileImage;
 
 	useEffect(() => {
 		setSelectedImage(profileImg);
-		setUserId(profileId);
+		setUserId(accountId);
 		setUserName(profileName);
 		setIntro(profileIntro);
 		setDisabled(false);
 	}, []);
 
 	useEffect(() => {
-		userId === profileId &&
+		userId === accountId &&
 		userName === profileName &&
 		intro === profileIntro &&
 		selectedImage === profileImg
@@ -78,7 +78,7 @@ export default function ProfileSetup() {
 
 	const postValidMutation = useMutation(postAccountValid, {
 		onSuccess: (data) => {
-			if (userId === profileId || data === '사용 가능한 계정ID 입니다.') {
+			if (userId === accountId || data === '사용 가능한 계정ID 입니다.') {
 				setIdDuplication(false);
 				setDisabled(false);
 			} else if (data === '이미 가입된 계정ID 입니다.') {
@@ -97,7 +97,7 @@ export default function ProfileSetup() {
 			setTimeout(() => {
 				setShowProfileEditToast(false);
 				localStorage.setItem('userAccountName', userId);
-				navigate(`../../${userId}`);
+				navigate(`../../../profile`);
 			}, 1000);
 		},
 		onError: () => {
@@ -108,12 +108,7 @@ export default function ProfileSetup() {
 	const validateUserId = async () => {
 		if (!userId || /^[A-Za-z0-9._]+$/.test(userId)) {
 			setNotValidUserId(false);
-			const data = {
-				user: {
-					accountname: userId,
-				},
-			};
-			postValidMutation.mutate(data);
+			postValidMutation.mutate(userId);
 		} else {
 			setNotValidUserId(true);
 			setIdDuplication(false);

--- a/src/pages/userProfile/MyProfileEdit.jsx
+++ b/src/pages/userProfile/MyProfileEdit.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import {
 	WrapForm,
 	InputStyle,
@@ -15,7 +14,6 @@ import {
 	LabelStyle,
 	ImageInput,
 } from './myProfileEdit.style.jsx';
-import { API_URL } from '../../api.js';
 import profilePic from '../../assets/image/profilePic.png';
 import profileImageUploadButton from '../../assets/image/profileImageUploadButton.png';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -31,7 +29,6 @@ import {
 } from '../../components/toast/toast.style';
 import { Helmet } from 'react-helmet';
 import imageValidation from '../../imageValidation.js';
-import { accessInstance, instance } from '../../api/axiosInstance.js';
 import { useMutation } from '@tanstack/react-query';
 import { postAccountValid, putProfileEdit } from '../../api/profileApi.js';
 

--- a/src/pages/userProfile/MyProfileEdit.jsx
+++ b/src/pages/userProfile/MyProfileEdit.jsx
@@ -33,36 +33,25 @@ import { useMutation } from '@tanstack/react-query';
 import { postAccountValid, putProfileEdit } from '../../api/profileApi.js';
 
 export default function ProfileSetup() {
-	const [userName, setUserName] = useState('');
-	const [userId, setUserId] = useState('');
-	const [intro, setIntro] = useState('');
-	const [selectedImage, setSelectedImage] = useState('');
+	const location = useLocation();
+	const profile = location.state.profile;
+	const [userName, setUserName] = useState(profile.username);
+	const [userId, setUserId] = useState(profile.accountname);
+	const [intro, setIntro] = useState(profile.intro);
+	const [selectedImage, setSelectedImage] = useState(profile.image);
 	const [idDuplication, setIdDuplication] = useState(false);
 	const [notValidUserId, setNotValidUserId] = useState(false);
 	const [disabled, setDisabled] = useState(true);
 	const [showProfileEditToast, setShowProfileEditToast] = useState(false);
 	const [showWrongExtensionToast, setShowWrongExtensionToast] = useState(false);
 	const [showSizeOverToast, setShowSizeOverToast] = useState(false);
-	const location = useLocation();
 	const navigate = useNavigate();
 	const accountId = localStorage.getItem('userAccountName');
-	const profileName = location.state.profileName;
-	const profileIntro = location.state.profileIntro;
-	const profileImg = location.state.profileImage;
 
 	useEffect(() => {
-		setSelectedImage(profileImg);
-		setUserId(accountId);
-		setUserName(profileName);
-		setIntro(profileIntro);
-		setDisabled(false);
-	}, []);
-
-	useEffect(() => {
-		userId === accountId &&
-		userName === profileName &&
-		intro === profileIntro &&
-		selectedImage === profileImg
+		userId === profile.accountname &&
+		userName === profile.username &&
+		intro === profile.intro
 			? setDisabled(false)
 			: setDisabled(true);
 	}, [userId]);
@@ -200,7 +189,7 @@ export default function ProfileSetup() {
 							onChange={handleImageInputChange}
 						/>
 						<ProfileImage
-							src={selectedImage || profileImg || profilePic}
+							src={selectedImage || profile.image || profilePic}
 							onError={handleImgError}
 							alt=''
 						/>{' '}

--- a/src/pages/userProfile/Profile.jsx
+++ b/src/pages/userProfile/Profile.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { PostDeleteContext } from '../post/PostDeleteContext.jsx';
 import {
 	ChatShare,
@@ -40,7 +40,12 @@ import ProductsForSale from './ProductsForSale.jsx';
 import Loading from '../../components/loading/Loading.jsx';
 import { Helmet } from 'react-helmet';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { delUnFollow, getUserInfo, postFollow } from '../../api/profileApi.js';
+import {
+	delUnFollow,
+	getMyInfo,
+	getUserInfo,
+	postFollow,
+} from '../../api/profileApi.js';
 import Page404 from '../page404/Page404.jsx';
 export default function UserProfile() {
 	const navigate = useNavigate();
@@ -54,14 +59,8 @@ export default function UserProfile() {
 	const { data: profile, isLoading } = useQuery(
 		// 매개변수 accountname 값이 변경될 때 마다 재요청
 		['profileData', accountname],
-		() => getUserInfo(accountname),
-		{ keepPreviousData: true }
-		// { enabled: !!accountname }
+		() => (accountname ? getUserInfo(accountname) : getMyInfo())
 	);
-
-	const handleImgError = (e) => {
-		e.target.src = profilePic;
-	};
 
 	const handleFollowChange = async (e) => {
 		e.preventDefault();
@@ -93,6 +92,10 @@ export default function UserProfile() {
 	const handleModalOpen = (e) => {
 		e.preventDefault();
 		setIsModal(true);
+	};
+
+	const handleImgError = (e) => {
+		e.target.src = profilePic;
 	};
 
 	const handleModalClose = (e) => {
@@ -134,7 +137,9 @@ export default function UserProfile() {
 				<ProfilePageWrapper>
 					<ProfileWrapper>
 						<ProfileImgWrap>
-							<FollowerWrap to='./follower'>
+							<FollowerWrap
+								to={accountname ? './follower' : `./${myaccountname}/follower`}
+							>
 								<FollowerNumber followers>
 									{profile.followerCount}
 								</FollowerNumber>
@@ -148,7 +153,11 @@ export default function UserProfile() {
 								alt={`${profile.accountname}의 프로필입니다.`}
 							></ProfileImage>
 
-							<FollowerWrap to='./following'>
+							<FollowerWrap
+								to={
+									accountname ? './following' : `./${myaccountname}/following`
+								}
+							>
 								<FollowerNumber>{profile.followingCount}</FollowerNumber>
 								<Follower>followings</Follower>
 							</FollowerWrap>
@@ -160,7 +169,7 @@ export default function UserProfile() {
 							<Intro>{profile.intro}</Intro>
 						</UserWrap>
 
-						{myaccountname === accountname ? (
+						{!accountname ? (
 							<ProfileButtonWrap>
 								<ProfileButton
 									type='button'
@@ -205,13 +214,17 @@ export default function UserProfile() {
 
 					{isLoading && <Loading />}
 
-					<ProductsForSale userAccountName={accountname} />
+					<ProductsForSale
+						userAccountName={!accountname ? myaccountname : accountname}
+					/>
 					{!isLoading && (
 						<PostDeleteContext.Provider
 							value={{ deletedPostId, setDeletedPostId }}
 						>
 							{' '}
-							<PostList accountname={accountname}></PostList>
+							<PostList
+								accountname={!accountname ? myaccountname : accountname}
+							></PostList>
 						</PostDeleteContext.Provider>
 					)}
 				</ProfilePageWrapper>

--- a/src/pages/userProfile/Profile.jsx
+++ b/src/pages/userProfile/Profile.jsx
@@ -21,6 +21,9 @@ import { BottomNavContainer } from '../../components/bottomnav/bottomnav.style.j
 import ProductsForSale from './ProductsForSale.jsx';
 import { Helmet } from 'react-helmet';
 import { useNavigate, useParams } from 'react-router-dom';
+import Page404 from '../page404/Page404.jsx';
+import { useQuery } from '@tanstack/react-query';
+import { postAccountValid } from '../../api/profileApi.js';
 export default function UserProfile() {
 	const [isModal, setIsModal] = useState(false);
 	const [isCheckModal, setIsCheckModal] = useState(false);
@@ -28,6 +31,14 @@ export default function UserProfile() {
 	const myaccountname = localStorage.getItem('userAccountName');
 	const accountname = useParams().accountUsername;
 	const navigate = useNavigate();
+
+	const { data: isUser, isLoading } = useQuery(
+		['isUserData', accountname],
+		() =>
+			accountname
+				? postAccountValid(accountname)
+				: postAccountValid(myaccountname)
+	);
 
 	const handleModalOpen = (e) => {
 		e.preventDefault();
@@ -69,19 +80,30 @@ export default function UserProfile() {
 				/>
 				<OptionModalTab onClick={handleModalOpen} />
 			</NavbarWrap>
-			<ProfilePageWrapper>
-				<ProfileCard />
+			{!isLoading && isUser === '이미 가입된 계정ID 입니다.' ? (
+				<>
+					<ProfilePageWrapper>
+						<ProfileCard />
 
-				<ProductsForSale
-					userAccountName={!accountname ? myaccountname : accountname}
-				/>
-				<PostDeleteContext.Provider value={{ deletedPostId, setDeletedPostId }}>
-					{' '}
-					<PostList
-						accountname={!accountname ? myaccountname : accountname}
-					></PostList>
-				</PostDeleteContext.Provider>
-			</ProfilePageWrapper>
+						<ProductsForSale
+							userAccountName={!accountname ? myaccountname : accountname}
+						/>
+						<PostDeleteContext.Provider
+							value={{ deletedPostId, setDeletedPostId }}
+						>
+							{' '}
+							<PostList
+								accountname={!accountname ? myaccountname : accountname}
+							></PostList>
+						</PostDeleteContext.Provider>
+					</ProfilePageWrapper>
+				</>
+			) : (
+				!isLoading &&
+				isUser !== '이미 가입된 계정ID 입니다.' && (
+					<Page404 message='User not Found' />
+				)
+			)}
 
 			{isModal && (
 				<DarkBackground onClick={handleModalClose}>

--- a/src/pages/userProfile/ProfileCard.jsx
+++ b/src/pages/userProfile/ProfileCard.jsx
@@ -17,7 +17,6 @@ import {
 	delUnFollow,
 	getMyInfo,
 	getUserInfo,
-	postAccountValid,
 	postFollow,
 } from '../../api/profileApi.js';
 import profilePic from '../../assets/image/profilePic.png';
@@ -28,7 +27,7 @@ import {
 } from '../../components/button/button.style.jsx';
 import Loading from '../../components/loading/Loading.jsx';
 
-export const ProfileCard = ({ setIsUser }) => {
+export const ProfileCard = () => {
 	const navigate = useNavigate();
 	const myaccountname = localStorage.getItem('userAccountName');
 	const accountname = useParams().accountUsername;

--- a/src/pages/userProfile/ProfileCard.jsx
+++ b/src/pages/userProfile/ProfileCard.jsx
@@ -13,12 +13,7 @@ import {
 } from './Profile.style.jsx';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-	delUnFollow,
-	getMyInfo,
-	getUserInfo,
-	postFollow,
-} from '../../api/profileApi.js';
+import { getMyInfo, getUserInfo } from '../../api/profileApi.js';
 import profilePic from '../../assets/image/profilePic.png';
 import { ProfileImage } from './myProfileEdit.style.jsx';
 import {
@@ -26,6 +21,7 @@ import {
 	ProfileButton,
 } from '../../components/button/button.style.jsx';
 import Loading from '../../components/loading/Loading.jsx';
+import { delUnFollow, postFollow } from '../../api/followApi.js';
 
 export const ProfileCard = () => {
 	const navigate = useNavigate();

--- a/src/pages/userProfile/ProfileCard.jsx
+++ b/src/pages/userProfile/ProfileCard.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import {
+	ProfileWrapper,
+	Intro,
+	UserEmail,
+	UserNickName,
+	Follower,
+	FollowerNumber,
+	FollowerWrap,
+	ProfileImgWrap,
+	UserWrap,
+	ProfileButtonWrap,
+} from './Profile.style.jsx';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+	delUnFollow,
+	getMyInfo,
+	getUserInfo,
+	postFollow,
+} from '../../api/profileApi.js';
+import profilePic from '../../assets/image/profilePic.png';
+import { ProfileImage } from './myProfileEdit.style.jsx';
+import {
+	ChatShare,
+	ProfileButton,
+} from '../../components/button/button.style.jsx';
+import Loading from '../../components/loading/Loading.jsx';
+
+export const ProfileCard = () => {
+	const navigate = useNavigate();
+	const myaccountname = localStorage.getItem('userAccountName');
+	const accountname = useParams().accountUsername;
+	const queryClient = useQueryClient();
+
+	const { data: profile, isLoading } = useQuery(
+		// 매개변수 accountname 값이 변경될 때 마다 재요청
+		['profileData', accountname],
+		() => (accountname ? getUserInfo(accountname) : getMyInfo())
+	);
+
+	console.log('렌더링했음');
+
+	const handleFollowChange = async (e) => {
+		e.preventDefault();
+		if (profile.isfollow) {
+			delFollowMutaion.mutate(accountname);
+		} else {
+			postFollowMutaion.mutate(accountname);
+		}
+	};
+
+	const delFollowMutaion = useMutation(delUnFollow, {
+		onSuccess: () => {
+			queryClient.invalidateQueries('profileData');
+		},
+		onError: () => {
+			console.error('실패');
+		},
+	});
+
+	const postFollowMutaion = useMutation(postFollow, {
+		onSuccess: () => {
+			queryClient.invalidateQueries('profileData');
+		},
+		onError: () => {
+			console.error('실패');
+		},
+	});
+
+	const handleImgError = (e) => {
+		e.target.src = profilePic;
+	};
+	return (
+		<>
+			{!isLoading ? (
+				<ProfileWrapper>
+					<ProfileImgWrap>
+						<FollowerWrap
+							to={accountname ? './follower' : `./${myaccountname}/follower`}
+						>
+							<FollowerNumber followers>{profile.followerCount}</FollowerNumber>
+							<Follower>followers</Follower>
+						</FollowerWrap>
+
+						<ProfileImage
+							style={{ width: '110px', height: '110px' }}
+							src={profile.image}
+							onError={handleImgError}
+							alt={`${profile.accountname}의 프로필입니다.`}
+						></ProfileImage>
+
+						<FollowerWrap
+							to={accountname ? './following' : `./${myaccountname}/following`}
+						>
+							<FollowerNumber>{profile.followingCount}</FollowerNumber>
+							<Follower>followings</Follower>
+						</FollowerWrap>
+					</ProfileImgWrap>
+
+					<UserWrap>
+						<UserNickName>{profile.username}</UserNickName>
+						<UserEmail>@ {profile.accountname}</UserEmail>
+						<Intro>{profile.intro}</Intro>
+					</UserWrap>
+
+					{!accountname ? (
+						<ProfileButtonWrap>
+							<ProfileButton
+								type='button'
+								onClick={() => {
+									navigate('./edit', {
+										state: {
+											profileImage: profile.image,
+											profileId: profile.accountname,
+											profileName: profile.username,
+											profileIntro: profile.intro,
+										},
+									});
+								}}
+							>
+								프로필 수정
+							</ProfileButton>
+
+							<ProfileButton
+								product
+								type='button'
+								onClick={() => {
+									navigate('../../Product/upload');
+								}}
+							>
+								상품 등록
+							</ProfileButton>
+						</ProfileButtonWrap>
+					) : (
+						<ProfileButtonWrap>
+							<ChatShare type='button' chatting />
+							<ProfileButton
+								follow={profile.isfollow === true ? false : true}
+								type='button'
+								onClick={(e) => handleFollowChange(e)}
+							>
+								{profile.isfollow === true ? '팔로우 취소' : '팔로우'}
+							</ProfileButton>
+							<ChatShare type='button' />
+						</ProfileButtonWrap>
+					)}
+				</ProfileWrapper>
+			) : (
+				<Loading />
+			)}
+		</>
+	);
+};

--- a/src/pages/userProfile/ProfileCard.jsx
+++ b/src/pages/userProfile/ProfileCard.jsx
@@ -17,6 +17,7 @@ import {
 	delUnFollow,
 	getMyInfo,
 	getUserInfo,
+	postAccountValid,
 	postFollow,
 } from '../../api/profileApi.js';
 import profilePic from '../../assets/image/profilePic.png';
@@ -27,7 +28,7 @@ import {
 } from '../../components/button/button.style.jsx';
 import Loading from '../../components/loading/Loading.jsx';
 
-export const ProfileCard = () => {
+export const ProfileCard = ({ setIsUser }) => {
 	const navigate = useNavigate();
 	const myaccountname = localStorage.getItem('userAccountName');
 	const accountname = useParams().accountUsername;
@@ -73,7 +74,7 @@ export const ProfileCard = () => {
 	};
 	return (
 		<>
-			{!isLoading ? (
+			{profile && !isLoading ? (
 				<ProfileWrapper>
 					<ProfileImgWrap>
 						<FollowerWrap
@@ -147,7 +148,7 @@ export const ProfileCard = () => {
 					)}
 				</ProfileWrapper>
 			) : (
-				<Loading />
+				isLoading && <Loading />
 			)}
 		</>
 	);

--- a/src/pages/userProfile/ProfileCard.jsx
+++ b/src/pages/userProfile/ProfileCard.jsx
@@ -40,8 +40,6 @@ export const ProfileCard = ({ setIsUser }) => {
 		() => (accountname ? getUserInfo(accountname) : getMyInfo())
 	);
 
-	console.log('렌더링했음');
-
 	const handleFollowChange = async (e) => {
 		e.preventDefault();
 		if (profile.isfollow) {
@@ -112,10 +110,7 @@ export const ProfileCard = ({ setIsUser }) => {
 								onClick={() => {
 									navigate('./edit', {
 										state: {
-											profileImage: profile.image,
-											profileId: profile.accountname,
-											profileName: profile.username,
-											profileIntro: profile.intro,
+											profile: profile,
 										},
 									});
 								}}

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -41,11 +41,11 @@ export default function Router() {
 					<Route path='/profile/' element={<Outlet />}>
 						<Route path='' element={<Profile />} />
 						<Route path='*' element={<Page404 />} />
+						<Route path='edit/' element={<MyProfileEdit />} />
 						<Route path=':accountUsername' element={<Outlet />}>
 							<Route path='' element={<Profile />} />
 							<Route path='*' element={<Page404 />} />
 							<Route path=':follow/' element={<Follow />}></Route>
-							<Route path='edit/' element={<MyProfileEdit />} />
 						</Route>
 					</Route>
 

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -39,7 +39,7 @@ export default function Router() {
 					</Route>
 
 					<Route path='/profile/' element={<Outlet />}>
-						<Route path='' element={<Page404 />} />
+						<Route path='' element={<Profile />} />
 						<Route path='*' element={<Page404 />} />
 						<Route path=':accountUsername' element={<Outlet />}>
 							<Route path='' element={<Profile />} />


### PR DESCRIPTION
## Motivation
- 프로필 페이지의 프로필 로직을 ProfileCard로 분리
- 프로필 수정 페이지 리액트 쿼리로 변경
- 없는 유저의 프로필로 URL을 통해서 이동할 경우 404 보이게 개선
- 팔로우 페이지 리액트 쿼리 변경 및 무한스크롤 로직 수정
- api 폴더안에 팔로우 페이지에서 사용할 axios API로직을 followApi를 생성하여 코드 개선
## Key Changes
- https://github.com/FRONTENDSCHOOL5/final-04-fearless4/issues/119
## To Reviewers
서로 상호작용하는 기능이 많아, profile 브랜치를 follow 브랜치로 통합해서 작업했습니다!
해당 이슈 관련하여 오류사항 발견 시 말씀부탁드립니다!