### PR TITLE
Follow, Profile 리팩토링

### DIFF
--- a/src/components/button/button.style.jsx
+++ b/src/components/button/button.style.jsx
@@ -3,6 +3,7 @@ import socialImg from '../../assets/image/social_login_sprites.png';
 import chat from '../../assets/icon/icon-message-circle.svg';
 import share from '../../assets/icon/share.svg';
 import UploadImage from '../../assets/icon/upload-image.svg';
+import { Link } from 'react-router-dom';
 
 export const SocialLoginButton = styled.button`
 	font-family: 'Suit-Regular';
@@ -64,14 +65,16 @@ export const LoginButton = styled.button`
 	cursor: ${({ disabled }) => (disabled === true ? 'not-allowed' : 'pointer')};
 `;
 
-export const ProfileButton = styled.button`
+export const ProfileButton = styled(Link)`
 	font-family: 'Suit-Regular';
+	text-align: center;
 	font-size: 14px;
 	font-weight: 500;
 	background-color: ${({ follow }) => (follow === true ? `#81d8d0` : `#fff`)};
 	display: block;
 	width: ${({ product }) => (product === true ? `100px` : `120px`)};
-	padding: 8px 0;
+	padding: 10px 0;
+	box-sizing: border-box;
 	color: ${({ follow }) => (follow === true ? `#fff` : `#767676`)};
 	border-radius: 30px;
 	border: ${({ follow }) =>

--- a/src/pages/follow/Follow.jsx
+++ b/src/pages/follow/Follow.jsx
@@ -5,7 +5,7 @@ import {
 	NavbarTitle,
 	NavbarWrap,
 } from '../../components/navbar/navbar.style';
-import { Wrapper } from './follow.style';
+import { FollowTitle, Wrapper } from './follow.style';
 import FollowUnknown from './FollowUnknown';
 import Loading from '../../components/loading/Loading';
 import { Helmet } from 'react-helmet';
@@ -19,7 +19,6 @@ export default function Follwers() {
 	const queryClient = useQueryClient();
 	const accountUsername = useParams().accountUsername;
 	const followPage = useParams().follow;
-	const myAccountName = localStorage.getItem('userAccountName');
 	const count = useRef(0);
 	const [ref, inView] = useInView();
 	const [hasNextPage, setHasNextPage] = useState(true);
@@ -31,14 +30,10 @@ export default function Follwers() {
 	} = useInfiniteQuery(
 		['getFollowData', accountUsername],
 		({
-			myName = myAccountName,
 			pageParam = count.current,
 			follow = followPage,
 			nextPage = setHasNextPage,
-		}) =>
-			accountUsername
-				? getFollow(accountUsername, pageParam, follow, nextPage)
-				: getFollow(myName, pageParam, follow, nextPage),
+		}) => getFollow(accountUsername, pageParam, follow, nextPage),
 		{
 			getNextPageParam: (lastPage) => lastPage.nextPage + 10,
 			refetchOnWindowFocus: false,
@@ -74,17 +69,22 @@ export default function Follwers() {
 					followPage === 'follower' ? 'Followers' : 'Followings'
 				}`}</NavbarTitle>
 			</NavbarWrap>
-			<Wrapper>
-				{followData?.pages[0].data.length > 0
-					? followData?.pages.map((page) =>
-							page.data.map((follow) => {
-								return <FollowItem key={follow._id} follow={follow} />;
-							})
-					  )
-					: !isLoading && <FollowUnknown />}
-				{isLoading && <Loading />}
-				{hasNextPage && <div ref={ref} />}
-			</Wrapper>
+			<main>
+				<FollowTitle>
+					{accountUsername + '의 ' + followPage + '페이지 '}
+				</FollowTitle>
+				<Wrapper>
+					{followData?.pages[0].data.length > 0
+						? followData?.pages.map((page) =>
+								page.data.map((follow) => {
+									return <FollowItem key={follow._id} follow={follow} />;
+								})
+						  )
+						: !isLoading && <FollowUnknown />}
+					{isLoading && <Loading />}
+					{hasNextPage && <div ref={ref} />}
+				</Wrapper>
+			</main>
 		</>
 	);
 }

--- a/src/pages/follow/FollowItem.jsx
+++ b/src/pages/follow/FollowItem.jsx
@@ -57,6 +57,7 @@ function FollowItem({ follow }) {
 	return (
 		<UserWrap key={follow._id}>
 			<UserFlexWrap
+				aria-label={`${follow.username} 프로필 이미지입니다. 클릭 시 해당 유저 프로필로 이동할 수 있습니다.`}
 				to={
 					myAccountName === follow.accountname
 						? '../../../profile'
@@ -77,6 +78,11 @@ function FollowItem({ follow }) {
 			</UserFlexWrap>
 			{!(myAccountName === follow.accountname) && (
 				<FollowButton
+					aria-label={
+						followButtonState
+							? `${follow.username}를 팔로우 취소하는 버튼입니다`
+							: `${follow.username}를 팔로우하는 버튼입니다.`
+					}
 					type='button'
 					follow={followButtonState}
 					onClick={(e) => handleFollowButtonClick(follow.accountname, e)}

--- a/src/pages/follow/FollowItem.jsx
+++ b/src/pages/follow/FollowItem.jsx
@@ -56,27 +56,21 @@ function FollowItem({ follow }) {
 
 	return (
 		<UserWrap key={follow._id}>
-			<UserFlexWrap>
-				<UserProfileImg
-					onClick={() => {
-						myAccountName === follow.accountname
-							? navigate('../../../profile')
-							: navigate(`../../${follow.accountname}`);
-					}}
-				>
+			<UserFlexWrap
+				to={
+					myAccountName === follow.accountname
+						? '../../../profile'
+						: `../../${follow.accountname}`
+				}
+			>
+				<UserProfileImg>
 					<UserFollowImage
 						src={follow.image}
 						onError={handleImgError}
 						alt={`${follow.username} 프로필 이미지입니다.`}
 					/>
 				</UserProfileImg>
-				<UserContent
-					onClick={() => {
-						myAccountName === follow.accountname
-							? navigate('../../../profile')
-							: navigate(`../../${follow.accountname}`);
-					}}
-				>
+				<UserContent>
 					<UserFollowNickName>{follow.username}</UserFollowNickName>
 					<UserFollowIntro>{follow.intro}</UserFollowIntro>
 				</UserContent>

--- a/src/pages/follow/FollowItem.jsx
+++ b/src/pages/follow/FollowItem.jsx
@@ -15,8 +15,6 @@ import { delUnFollow, postFollow } from '../../api/followApi';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 function FollowItem({ follow }) {
-	const navigate = useNavigate();
-	const queryClient = useQueryClient();
 	const myAccountName = localStorage.getItem('userAccountName');
 	const [followButtonState, setFollowButtonState] = useState(follow.isfollow);
 

--- a/src/pages/follow/follow.style.jsx
+++ b/src/pages/follow/follow.style.jsx
@@ -1,6 +1,7 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.ul`
 	width: 100%;
 	box-sizing: border-box;
 	padding: 16px 16px;
@@ -9,17 +10,19 @@ export const Wrapper = styled.div`
 	gap: 22px;
 `;
 
-export const UserWrap = styled.div`
+export const UserWrap = styled.li`
 	width: 100%;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 `;
 
-export const UserFlexWrap = styled.div`
+export const UserFlexWrap = styled(Link)`
+	width: 100%;
 	display: flex;
 	align-items: center;
 	gap: 12px;
+	cursor: pointer;
 `;
 
 export const UserProfileImg = styled.div`
@@ -44,12 +47,12 @@ export const UserContent = styled.div`
 	cursor: pointer;
 `;
 
-export const UserFollowNickName = styled.span`
+export const UserFollowNickName = styled.p`
 	font-size: 14px;
 	font-family: 'Suit-Bold';
 `;
 
-export const UserFollowIntro = styled.span`
+export const UserFollowIntro = styled.p`
 	font-size: 12px;
 	font-weight: 400;
 	overflow: hidden;
@@ -73,4 +76,15 @@ export const LoadingText = styled.span`
 	font-size: 16px;
 	text-align: center;
 	color: black;
+`;
+
+export const FollowTitle = styled.h1`
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
 `;

--- a/src/pages/follow/follow.style.jsx
+++ b/src/pages/follow/follow.style.jsx
@@ -48,11 +48,13 @@ export const UserContent = styled.div`
 `;
 
 export const UserFollowNickName = styled.p`
+	color: black;
 	font-size: 14px;
 	font-family: 'Suit-Bold';
 `;
 
 export const UserFollowIntro = styled.p`
+	color: black;
 	font-size: 12px;
 	font-weight: 400;
 	overflow: hidden;

--- a/src/pages/userProfile/Profile.jsx
+++ b/src/pages/userProfile/Profile.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PostDeleteContext } from '../post/PostDeleteContext.jsx';
-import { ProfilePageWrapper } from './Profile.style.jsx';
+import { ProfilePageWrapper, ProfileTitle } from './Profile.style.jsx';
 import { ProfileCard } from './ProfileCard.jsx';
 import {
 	Backspace,
@@ -83,8 +83,10 @@ export default function UserProfile() {
 			{!isLoading && isUser === '이미 가입된 계정ID 입니다.' ? (
 				<>
 					<ProfilePageWrapper>
+						<ProfileTitle>
+							{(!accountname ? myaccountname : accountname) + '의 프로필'}
+						</ProfileTitle>
 						<ProfileCard />
-
 						<ProductsForSale
 							userAccountName={!accountname ? myaccountname : accountname}
 						/>

--- a/src/pages/userProfile/Profile.style.jsx
+++ b/src/pages/userProfile/Profile.style.jsx
@@ -52,7 +52,7 @@ export const Follower = styled.span`
 	color: #767676;
 `;
 
-export const FollowerWrap = styled.button`
+export const FollowerWrap = styled(Link)`
 	width: 55px;
 	flex-shrink: 0;
 	border: 0;

--- a/src/pages/userProfile/Profile.style.jsx
+++ b/src/pages/userProfile/Profile.style.jsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-export const ProfilePageWrapper = styled.div`
+export const ProfilePageWrapper = styled.main`
 	background-color: #f2f2f2;
 
 	display: flex;
@@ -9,7 +9,7 @@ export const ProfilePageWrapper = styled.div`
 	gap: 12px;
 `;
 
-export const ProfileWrapper = styled.div`
+export const ProfileWrapper = styled.section`
 	width: 100%;
 	position: relative;
 	box-sizing: border-box;
@@ -52,11 +52,16 @@ export const Follower = styled.span`
 	color: #767676;
 `;
 
-export const FollowerWrap = styled(Link)`
+export const FollowerWrap = styled.button`
+	width: 55px;
+	flex-shrink: 0;
+	border: 0;
+	background-color: transparent;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	gap: 6px;
+	cursor: pointer;
 `;
 
 export const ProfileImgWrap = styled.div`
@@ -77,4 +82,13 @@ export const ProfileButtonWrap = styled.div`
 	gap: 12px;
 `;
 
-export const ProductWrap = styled.div``;
+export const ProfileTitle = styled.h1`
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+`;

--- a/src/pages/userProfile/ProfileCard.jsx
+++ b/src/pages/userProfile/ProfileCard.jsx
@@ -111,25 +111,15 @@ export const ProfileCard = () => {
 					{!accountname ? (
 						<ProfileButtonWrap>
 							<ProfileButton
-								type='button'
-								onClick={() => {
-									navigate('./edit', {
-										state: {
-											profile: profile,
-										},
-									});
+								to={'./edit'}
+								state={{
+									profile: profile,
 								}}
 							>
 								프로필 수정
 							</ProfileButton>
 
-							<ProfileButton
-								product
-								type='button'
-								onClick={() => {
-									navigate('../../Product/upload');
-								}}
-							>
+							<ProfileButton product to={'../../Product/upload'}>
 								상품 등록
 							</ProfileButton>
 						</ProfileButtonWrap>

--- a/src/pages/userProfile/ProfileCard.jsx
+++ b/src/pages/userProfile/ProfileCard.jsx
@@ -71,7 +71,16 @@ export const ProfileCard = () => {
 				<ProfileWrapper>
 					<ProfileImgWrap>
 						<FollowerWrap
-							to={accountname ? './follower' : `./${myaccountname}/follower`}
+							aria-label={`${
+								!accountname ? myaccountname : accountname
+							}님이 현재 ${
+								profile.followerCount
+							}명이 팔로워 중 입니다. 버튼 클릭 시 팔로워된 유저 수를 확인할 수 있습니다.`}
+							onClick={() => {
+								accountname
+									? navigate('./follower')
+									: navigate(`./${myaccountname}/follower`);
+							}}
 						>
 							<FollowerNumber followers>{profile.followerCount}</FollowerNumber>
 							<Follower>followers</Follower>
@@ -85,7 +94,16 @@ export const ProfileCard = () => {
 						></ProfileImage>
 
 						<FollowerWrap
-							to={accountname ? './following' : `./${myaccountname}/following`}
+							aria-label={`${
+								!accountname ? myaccountname : accountname
+							}님이 현재 ${
+								profile.followingCount
+							}명이 팔로잉 중 입니다. 버튼 클릭 시 팔로잉한 유저 수를 확인할 수 있습니다.`}
+							onClick={() => {
+								accountname
+									? navigate('./following')
+									: navigate(`./${myaccountname}/following`);
+							}}
 						>
 							<FollowerNumber>{profile.followingCount}</FollowerNumber>
 							<Follower>followings</Follower>

--- a/src/pages/userProfile/ProfileCard.jsx
+++ b/src/pages/userProfile/ProfileCard.jsx
@@ -75,12 +75,8 @@ export const ProfileCard = () => {
 								!accountname ? myaccountname : accountname
 							}님이 현재 ${
 								profile.followerCount
-							}명이 팔로워 중 입니다. 버튼 클릭 시 팔로워된 유저 수를 확인할 수 있습니다.`}
-							onClick={() => {
-								accountname
-									? navigate('./follower')
-									: navigate(`./${myaccountname}/follower`);
-							}}
+							}명이 팔로워 중 입니다. 클릭 시 팔로워된 유저 수를 확인할 수 있습니다.`}
+							to={accountname ? './follower' : `./${myaccountname}/follower`}
 						>
 							<FollowerNumber followers>{profile.followerCount}</FollowerNumber>
 							<Follower>followers</Follower>
@@ -99,11 +95,7 @@ export const ProfileCard = () => {
 							}님이 현재 ${
 								profile.followingCount
 							}명이 팔로잉 중 입니다. 버튼 클릭 시 팔로잉한 유저 수를 확인할 수 있습니다.`}
-							onClick={() => {
-								accountname
-									? navigate('./following')
-									: navigate(`./${myaccountname}/following`);
-							}}
+							to={accountname ? './following' : `./${myaccountname}/following`}
 						>
 							<FollowerNumber>{profile.followingCount}</FollowerNumber>
 							<Follower>followings</Follower>


### PR DESCRIPTION
## Motivation
- 웹 접근성을 고려하여 시맨틱 태그로 변경
- 스크린리더를 고려하여 페이지 좀 더 명확하게 설명할 수 있도록 개선
## Key Changes
- 프로필 및 팔로우 페이지 시맨틱 태그로 변경
- 프로필 및 팔로우 페이지의 제목을 a11y-hidden을 이용하여 스크린리더로 읽을 수 있게 개선
- 일부 포커스 이동 안되는 태그 되게 개선
- 불분명한 태그를 aria-label 속성을 이용하여 명확하게 설명
- a태그는 링크이동, 버튼태그는 링크이동을 제외한 기능
## To Reviewers
- PR과 관련하여 오류 및 문제 발생 시 말씀 부탁드립니다!